### PR TITLE
feat: demo wallet warning and export connection secret

### DIFF
--- a/lib/state/appStore.ts
+++ b/lib/state/appStore.ts
@@ -30,6 +30,7 @@ type Wallet = {
   nostrWalletConnectUrl?: string;
   lightningAddress?: string;
   nwcCapabilities?: Nip47Capability[];
+  isCustodial?: boolean;
 };
 
 type AddressBookEntry = {

--- a/pages/settings/wallets/DemoWallets.tsx
+++ b/pages/settings/wallets/DemoWallets.tsx
@@ -23,8 +23,11 @@ let relays = [
 ];
 
 type DemoWalletsProps = {
-  connect(nwcUrl: string, lightningAddress?: string): void;
-  cancel(): void;
+  connect(
+    nwcUrl: string,
+    lightningAddress?: string,
+    isCustodial?: boolean,
+  ): void;
 };
 
 type Jim = {
@@ -47,7 +50,7 @@ type Jim = {
   };
 };
 
-export function DemoWallets({ connect, cancel }: DemoWalletsProps) {
+export function DemoWallets({ connect }: DemoWalletsProps) {
   const [jims, setJims] = React.useState<Jim[]>([]);
   const [creatingWalletForJim, setCreatingWalletForJim] = React.useState("");
   const [loadingEvents, setLoadingEvents] = React.useState(false);
@@ -139,7 +142,7 @@ export function DemoWallets({ connect, cancel }: DemoWalletsProps) {
                 }
                 const { connectionSecret, lightningAddress } =
                   await response.json();
-                await connect(connectionSecret, lightningAddress);
+                await connect(connectionSecret, lightningAddress, true);
               } catch (error) {
                 console.error("failed to create wallet", error);
                 return;

--- a/pages/settings/wallets/EditWallet.tsx
+++ b/pages/settings/wallets/EditWallet.tsx
@@ -1,5 +1,6 @@
 import { Link, router, Stack } from "expo-router";
 import { Alert, Pressable, View } from "react-native";
+import Toast from "react-native-toast-message";
 
 import {
   Card,
@@ -10,6 +11,8 @@ import {
 import { Text } from "~/components/ui/text";
 import { DEFAULT_WALLET_NAME } from "~/lib/constants";
 import { useAppStore } from "~/lib/state/appStore";
+import * as Clipboard from "expo-clipboard";
+import { AlertCircle } from "~/components/Icons";
 
 export function EditWallet() {
   const selectedWalletId = useAppStore((store) => store.selectedWalletId);
@@ -34,6 +37,37 @@ export function EditWallet() {
         <Text>
           Warning: Your wallet does not support list_transactions capability.
         </Text>
+      )}
+      {wallets[selectedWalletId].isCustodial && (
+        <>
+          <Card className="w-full">
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <View className="flex flex-row gap-2">
+                  <AlertCircle className="text-primary-foreground w-4 h-4" />
+                  <Text>Demo Wallet</Text>
+                </View>
+              </CardTitle>
+              <CardDescription>
+                You don't own the keys to your bitcoin and using a trusted
+                third-party. Limit the amount of sats you store in this wallet.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+
+          <Link className="" href="https://albyhub.com" asChild>
+            <Pressable>
+              <Card className="w-full">
+                <CardHeader>
+                  <CardTitle>Try Alby Hub</CardTitle>
+                  <CardDescription>
+                    Your Own Center for Internet Money
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </Pressable>
+          </Link>
+        </>
       )}
       <Link href={`/settings/wallets/${selectedWalletId}/name`} asChild>
         <Pressable>
@@ -77,6 +111,47 @@ export function EditWallet() {
           </Card>
         </Pressable>
       </Link>
+      <Pressable
+        onPress={() => {
+          Alert.alert(
+            "Export Wallet",
+            "Your Wallet Connection Secret will be copied to the clipboard which you can add to another app. For per-app permission management, try out Alby Hub or add your Wallet Connection Secret to an Alby Account.",
+            [
+              {
+                text: "Cancel",
+                style: "cancel",
+              },
+              {
+                text: "Confirm",
+                onPress: () => {
+                  const nwcUrl =
+                    useAppStore.getState().wallets[
+                      useAppStore.getState().selectedWalletId
+                    ].nostrWalletConnectUrl;
+                  if (!nwcUrl) {
+                    return;
+                  }
+                  Clipboard.setStringAsync(nwcUrl);
+                  Toast.show({
+                    type: "success",
+                    text1: "Connection Secret copied to clipboard",
+                  });
+                },
+              },
+            ],
+          );
+        }}
+      >
+        <Card className="w-full">
+          <CardHeader className="w-full">
+            <CardTitle className="flex flex-col">Export Wallet</CardTitle>
+            <CardDescription>
+              Copy your wallet's Connection Secret which can be imported into
+              another app
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </Pressable>
       <Pressable
         onPress={() => {
           Alert.alert(

--- a/pages/settings/wallets/WalletConnection.tsx
+++ b/pages/settings/wallets/WalletConnection.tsx
@@ -66,6 +66,7 @@ export function WalletConnection() {
   async function connect(
     nostrWalletConnectUrl: string,
     lightningAddress?: string,
+    isCustodial?: boolean,
   ) {
     try {
       setConnecting(true);
@@ -83,6 +84,7 @@ export function WalletConnection() {
       useAppStore.getState().updateCurrentWallet({
         nwcCapabilities: capabilities,
         ...(lightningAddress ? { lightningAddress } : {}),
+        isCustodial,
       });
       useAppStore.getState().setNWCClient(nwcClient);
       Toast.show({
@@ -158,12 +160,7 @@ export function WalletConnection() {
           </Button>
         </View>
       )}
-      {!hasConnection && showDemoWallets && (
-        <DemoWallets
-          connect={connect}
-          cancel={() => setShowDemoWallets(false)}
-        />
-      )}
+      {!hasConnection && showDemoWallets && <DemoWallets connect={connect} />}
       {!hasConnection && !showDemoWallets && (
         <>
           {isConnecting && (


### PR DESCRIPTION
Adds a warning in the edit wallet page if you use a demo wallet, and recommends Alby Hub. Also adds a way to export the connection secret