### PR TITLE
feat: camera permissions

### DIFF
--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -186,19 +186,6 @@ export function Send() {
               </View>
             </TouchableWithoutFeedback>
           )}
-          {permissionStatus === PermissionStatus.UNDETERMINED && !keyboardOpen && (
-            <>
-              <View className="flex-1 h-full flex flex-col items-center justify-center gap-5">
-                <View className="flex flex-col gap-2 items-center">
-                  <CameraIcon className="text-foreground" size={72} />
-                  <Text className="text-2xl text-foreground">Camera Permissions Needed</Text>
-                </View>
-                <Button onPress={scan}>
-                  <Text className="text-background">Grant Permissions</Text>
-                </Button>
-              </View>
-            </>
-          )}
           {!keyboardOpen &&
             <View className="flex flex-row items-stretch justify-center gap-4 p-6">
               <Button

--- a/pages/send/Send.tsx
+++ b/pages/send/Send.tsx
@@ -155,7 +155,7 @@ export function Send() {
             <View className="flex-1 h-full flex flex-col items-center justify-center gap-2 p-6">
               <CameraIcon className="text-foreground" size={72} />
               <Text className="text-2xl text-foreground text-center">Camera Permissions Denied</Text>
-              <Text className="text-muted-foreground text-xl text-center">It seems you denied permissions to use your camera. You might need to go to your operating system settings to allow access to your camera again.</Text>
+              <Text className="text-muted-foreground text-xl text-center">It seems you denied permissions to use your camera. You might need to go to your device settings to allow access to your camera again.</Text>
             </View>
           }
           {keyboardOpen && (

--- a/pages/settings/Wallets.tsx
+++ b/pages/settings/Wallets.tsx
@@ -36,19 +36,21 @@ export function Wallets() {
                     }
                   }}
                   className={cn(
-                    "flex flex-row items-center justify-between p-6 rounded-2xl border-2",
+                    "flex flex-row items-center justify-between p-4 rounded-2xl border-2",
                     active ? "border-primary" : "border-transparent",
                   )}
                 >
-                  <View className="flex flex-row gap-4 items-center">
-                    <Wallet2 className="text-foreground" />
+                  <View className="flex flex-row gap-4">
+                    <Wallet2 className="w-4 h-4 text-foreground" />
                     <Text className={cn("text-xl", active && "font-semibold2")}>
                       {item.item.name || DEFAULT_WALLET_NAME}
                     </Text>
                   </View>
                   {active && (
-                    <Link href={`/settings/wallets/${selectedWalletId}`} className="p-3 absolute right-2">
-                      <Settings2 className="text-foreground w-8 h-8" />
+                    <Link href={`/settings/wallets/${selectedWalletId}`}>
+                      <View className="p-4">
+                        <Settings2 className="text-foreground w-8 h-8" />
+                      </View>
                     </Link>
                   )}
                 </Pressable>

--- a/pages/settings/Wallets.tsx
+++ b/pages/settings/Wallets.tsx
@@ -36,21 +36,19 @@ export function Wallets() {
                     }
                   }}
                   className={cn(
-                    "flex flex-row items-center justify-between p-4 rounded-2xl border-2",
+                    "flex flex-row items-center justify-between p-6 rounded-2xl border-2",
                     active ? "border-primary" : "border-transparent",
                   )}
                 >
-                  <View className="flex flex-row gap-4">
-                    <Wallet2 className="w-4 h-4 text-foreground" />
+                  <View className="flex flex-row gap-4 items-center">
+                    <Wallet2 className="text-foreground" />
                     <Text className={cn("text-xl", active && "font-semibold2")}>
                       {item.item.name || DEFAULT_WALLET_NAME}
                     </Text>
                   </View>
                   {active && (
-                    <Link href={`/settings/wallets/${selectedWalletId}`}>
-                      <View className="p-4">
-                        <Settings2 className="text-foreground w-8 h-8" />
-                      </View>
+                    <Link href={`/settings/wallets/${selectedWalletId}`} className="p-3 absolute right-2">
+                      <Settings2 className="text-foreground w-8 h-8" />
                     </Link>
                   )}
                 </Pressable>


### PR DESCRIPTION
 - Allow users to use the app without camera permissions (show buttons below camera)
 - After you repeatedly denied camera permissions the permission requests will stop working on Android (you need to go to the app settings to reset it I think, don't know the behavior on iOS)
 - Don't know if we still need the screen asking you to grant permissions (on Android that happens automatically via the useEffect() call)